### PR TITLE
Add github templates and contribution links

### DIFF
--- a/.github/COMMIT_FORMAT.md
+++ b/.github/COMMIT_FORMAT.md
@@ -1,0 +1,105 @@
+Commit Message Formatting
+=========================
+
+*Based on the [Git Commit Msg][karma-git-format] format described by Karma.*
+
+## Format of a commit message:
+
+First line cannot be longer than 70 characters, second line is always
+blank and other lines should be wrapped at 80 characters.
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+### Message subject
+
+A message subject is required and **must not** be preceded by a
+newline. The contents of a message subject should not be longer than 70
+characters and should not wrap onto the next line. If a message subject
+is too long, then it should be made smaller and a more verbose message
+should be in the [message body][#message-body].
+
+**Allowed `<type>` values:**
+
+* **feat** (new feature)
+* **fix** (bug fix)
+* **docs** (changes to documentation)
+* **style** (formatting, missing semicolons, etc; no code change)
+* **refactor** (refactoring production code)
+* **test** (adding missing tests, refactoring tests; no production code change)
+* **chore** (updating grunt tasks etc; no production code change)
+
+**Example `<scope>` values:**
+* init
+* runner
+* watcher
+* config
+* web-server
+* proxy
+* etc.
+
+*The `<scope>` can be empty (eg. if the change is a global or difficult to
+assign to a single component), in which case the parentheses are
+omitted.*
+
+### Message body
+
+A message body is optional and must be preceded by a new line after the
+message subject. The contents of the message body should be wrapped at 80
+characters.
+
+A message body should:
+
+* use the imperative, present tense: “change” not “changed” nor “changes”
+* include motivation for the change and contrasts with previous behavior
+
+***For more info about message body, see:***
+* http://365git.tumblr.com/post/3308646748/writing-git-commit-messages
+* http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+
+### Message footer
+
+A message footer is optional and must be preceded by a new line after the
+message body. The contents of the message footer should be wrapped at 80
+characters.
+
+A message footer could include the following:
+
+**Referencing issues:**
+
+Closed issues should be listed on a separate line in the footer prefixed
+with "Closes" keyword like this:
+
+```
+Closes #234
+```
+
+or in case of multiple issues:
+
+```
+Closes #123, #245, #992
+```
+
+**Breaking changes:**
+
+All breaking changes have to be mentioned in footer with the description
+of the change, justification and migration notes.
+
+```
+BREAKING CHANGE:
+
+`port-runner` command line option has changed to `runner-port`, so that
+it is
+consistent with the configuration file syntax.
+
+To migrate your project, change all the commands, where you use
+`--port-runner` to `--runner-port`.
+
+```
+
+[karma-git-format]: http://karma-runner.github.io/0.10/dev/git-commit-msg.html

--- a/.github/COMMIT_FORMAT_EXAMPLES.md
+++ b/.github/COMMIT_FORMAT_EXAMPLES.md
@@ -1,0 +1,69 @@
+Commit Message Examples
+=======================
+
+## Chores
+
+A `chore` type is a task not directly tied to a feature, fix, or test. It is
+often work that requires no change to production code.
+
+```
+chore(scripts/): Moved extraneous scripts into scripts/ directory
+```
+
+## Documentation
+
+A `docs` type is a task that directly affects documentation that is
+constructed manually, programmatically, or through a third-party. This
+can include typos, additions, deletions, and examples.
+
+```
+docs(resolve.js): Describe new resolve API
+```
+
+## Features
+
+A `feat` type is a task that introduces a new feature. The new feature
+may introduce a breaking change to production code.
+
+```
+feat(create.js): Introduce new identity creation
+```
+
+## Fixes/bugs
+
+A `fix` type is a task that addresses a bug in production code, build
+scripts, compilation steps, or anything that directly or indiretly breaks or
+impacts production.
+
+```
+fix(buffer.js): Fix the freeing of buffer resources
+```
+
+## Refactoring
+
+A `refactor` type is a task that changes existing code. A refactor
+should be an improvement to the existing production code.
+
+```
+refactor(platform.js): Simplify platform logic
+```
+
+## Code style
+
+A `style` type is a task that addresses code formatting such as missing
+semicolons, converting tabs to spaces, or removing extra newlines. There
+should not be any code changes.
+
+```
+style(drive.js): Convert tabs to spaces
+```
+
+## Tests
+
+A `test` type is a task that addresses the testing of production code.
+This may include adding a new or missing test, refactoring existing
+tests, or removing useless tests. There should not be any code changes.
+
+```
+test(buffer.js): Fix broken buffer alloc logic
+```

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing
+
+When contributing to this repository, please first discuss the change you wish to make via issue,
+email, or any other method with the owners of this repository before making a change.
+
+Please note we have a code of conduct, please follow it in all your interactions with the project.
+
+## Pull Request Process
+
+1. Ensure any install or build dependencies are removed before the end of the layer when doing a
+   build.
+2. Update the README.md with details of changes to the interface, this includes new environment
+   variables, exposed ports, useful file locations and container parameters.
+3. Increase the version numbers in any examples files and the README.md to the new version that this
+   Pull Request would represent. The versioning scheme we use is [SemVer](http://semver.org/).
+4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you
+   do not have permission to do that, you may request the second reviewer to merge it for you.
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at dev@littlstar.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Expected Behavior
+
+
+## Actual Behavior
+
+
+## Steps to Reproduce the Problem
+
+  1.
+  2.
+  3.
+
+## Specifications
+
+  - Version:
+  - Platform:
+  - Subsystem:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+Fixes #
+
+## Proposed Changes
+
+  -
+  -
+  -

--- a/README.md
+++ b/README.md
@@ -44,12 +44,24 @@ info("fatal: ", someMessage)
 
 ### `console.warn(format, ...message)`
 
-Prints a formatted warn message to stderr.
+Prints a formatted warn message to `stderr`.
 
 ```js
 const { warn } = require('ara-console')
 warn("fatal: ", someMessage)
 ```
+
+## Contributing
+
+- [Commit message format](/.github/COMMIT_FORMAT.md)
+- [Commit message examples](/.github/COMMIT_FORMAT_EXAMPLES.md)
+- [How to contribute](/.github/CONTRIBUTING.md)
+
+Releases follow [Semantic Versioning](https://semver.org/)
+
+## See Also
+
+- [Log](https://goo.gl/6pm7Re)
 
 ## License
 


### PR DESCRIPTION
Fixes # N/A
 ## Proposed Changes
  - Add `.github/` directory
  - Add contribution links to `README`
 